### PR TITLE
Proposal to move the responsibilities of the Box3DWorld over to an interface

### DIFF
--- a/Box3D.Hybrid.Editor/Box3DEditorSimulation.cs
+++ b/Box3D.Hybrid.Editor/Box3DEditorSimulation.cs
@@ -1,5 +1,7 @@
+
 using System;
 using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
 using Unity.Mathematics;
 using UnityEngine;
 
@@ -11,7 +13,7 @@ namespace Box3D.Hybrid.Editor
     /// (the rope preview's recipe), so what settles here is what play mode would produce. Also
     /// owns the mouse grab: a kinematic anchor tied to the grabbed body by a ball joint, with the
     /// anchor smoothed toward the cursor so dragging feels springy instead of violent.</summary>
-    internal sealed class Box3DEditorSimulation : IDisposable
+    internal sealed class Box3DEditorSimulation : IDisposable, IBox3DWorld
     {
         private const int SubSteps = 4;
         // Time constant of the anchor's chase toward the cursor — lower is snappier.
@@ -48,6 +50,26 @@ namespace Box3D.Hybrid.Editor
         /// <summary>Where the cursor is pulling the grabbed body toward (valid while grabbing).</summary>
         internal Vector3 GrabTarget => (Vector3)_grabTarget;
 
+        public World PhysicsWorld => _world;
+
+        public Vector3 Gravity { get => _world.GetGravity(); set => _world.SetGravity(value); }
+
+        public Vector3 GravityDirection
+        {
+            get
+            {
+                Vector3 absolute = new(Mathf.Abs(this.Gravity.x), Mathf.Abs(this.Gravity.y), Mathf.Abs(this.Gravity.z));
+                return absolute.normalized;
+            }
+        }
+
+        public bool IsPaused { get => false; set { } }
+
+        public bool IsValid => _world.IsValid;
+
+        public Body WorldAnchor => _grabAnchor;
+
+
         /// <summary>Builds the preview world. <paramref name="bodies"/> must be ordered parents
         /// before children so the write-back leaves nested bodies at their simulated world pose.</summary>
         internal Box3DEditorSimulation(IReadOnlyList<Box3DBody> bodies)
@@ -57,13 +79,13 @@ namespace Box3D.Hybrid.Editor
             Box3DRuntime.Install();
 
             WorldDef worldDef = WorldDef.Default;
-            worldDef.Gravity = SceneGravity();
+            worldDef.Gravity = IBox3DWorld.GetSceneGravity(null);
             _world = World.Create(worldDef);
 
             var simulated = new HashSet<Box3DBody>(bodies);
             foreach (Box3DBody body in bodies)
             {
-                CreateDynamic(body);
+                AddBody(body);
             }
             ReplicateStaticScene(simulated);
         }
@@ -173,7 +195,7 @@ namespace Box3D.Hybrid.Editor
 
         // Mirrors Box3DBody.Awake: a dynamic body at the component's pose, compound shapes gathered
         // from the hierarchy (stopping at nested bodies) and attached at their local frames.
-        private void CreateDynamic(Box3DBody component)
+        public void AddBody(Box3DBody component)
         {
             Transform root = component.transform;
 
@@ -210,6 +232,11 @@ namespace Box3D.Hybrid.Editor
             _entries.Add(new Entry { Component = component, Body = body });
         }
 
+        public void RemoveBody(Box3DBody body)
+        {
+            // no implementation here
+        }
+
         // Every enabled scene shape that doesn't belong to a simulated body becomes static
         // collision at its current pose — the rest of the scene is frozen, exactly like play mode
         // would collide with it if nothing else moved.
@@ -228,12 +255,6 @@ namespace Box3D.Hybrid.Editor
                 shape.CreateDetachedShape(body);
                 _replicated.Add(shape);
             }
-        }
-
-        private static Vector3 SceneGravity()
-        {
-            var world = UnityEngine.Object.FindAnyObjectByType<Box3DWorld>();
-            return world ? world.GravityVector : new Vector3(0f, -9.81f, 0f);
         }
     }
 }

--- a/Box3D.Hybrid/Box3DBallJoint.cs
+++ b/Box3D.Hybrid/Box3DBallJoint.cs
@@ -1,3 +1,4 @@
+
 using UnityEngine;
 
 namespace Box3D.Hybrid
@@ -47,7 +48,7 @@ namespace Box3D.Hybrid
                 def.UpperTwistAngle = Mathf.Max(MinTwist, MaxTwist) * Mathf.Deg2Rad;
             }
 
-            _ball = World.World.CreateSphericalJoint(def);
+            _ball = IBox3DWorld.Get(this).PhysicsWorld.CreateSphericalJoint(def);
             return _ball;
         }
 

--- a/Box3D.Hybrid/Box3DBody.cs
+++ b/Box3D.Hybrid/Box3DBody.cs
@@ -39,7 +39,6 @@ namespace Box3D.Hybrid
         [SerializeField, Tooltip("Allow fast rotation (e.g. spinning wheels) without box3d clamping angular velocity.")]
         private bool AllowFastRotation;
 
-        private Box3DWorld _world;
         private Body _body;
         private Box3DShape[] _shapes;
         private IBox3DHitReceiver[] _hitReceivers;
@@ -64,8 +63,10 @@ namespace Box3D.Hybrid
 
                 _body.SetType(ToNative(value));
                 bool isKinematic = value == Box3DBodyType.Kinematic;
-                if (isKinematic && !wasKinematic) _world.AddKinematic(this);
-                else if (!isKinematic && wasKinematic) _world.RemoveKinematic(this);
+                IBox3DWorld world = IBox3DWorld.Get(this);
+                if (!IBox3DWorld.Validate(world)) return;
+                if (isKinematic && !wasKinematic) world.AddBody(this);
+                else if (!isKinematic && wasKinematic) world.RemoveBody(this);
             }
         }
 
@@ -97,7 +98,9 @@ namespace Box3D.Hybrid
 
         private void Awake()
         {
-            _world = Box3DWorld.Instance;
+
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
 
             BodyDef def = BodyDef.Default;
             def.Type = ToNative(Type);
@@ -111,7 +114,7 @@ namespace Box3D.Hybrid
 
             _handle = GCHandle.Alloc(this);
             def.UserData = GCHandle.ToIntPtr(_handle);
-            _body = _world.World.CreateBody(def);
+            _body = world.PhysicsWorld.CreateBody(def);
             _body.SetName(gameObject.name); // recorded — lets the visual replayer map replay bodies to scene objects
 
             var shapes = new System.Collections.Generic.List<Box3DShape>();
@@ -133,7 +136,7 @@ namespace Box3D.Hybrid
                     ownerData, _hitReceivers.Length > 0);
             }
 
-            if (Type == Box3DBodyType.Kinematic) _world.AddKinematic(this);
+            if (Type == Box3DBodyType.Kinematic) world.AddBody(this);
             transform.hasChanged = false;
         }
 
@@ -152,7 +155,12 @@ namespace Box3D.Hybrid
 
         private void OnDestroy()
         {
-            if (Type == Box3DBodyType.Kinematic && _world) _world.RemoveKinematic(this);
+            if (Type == Box3DBodyType.Kinematic)
+            {
+                IBox3DWorld world = IBox3DWorld.Get(this);
+                if (IBox3DWorld.Validate(world))
+                    world.RemoveBody(this);
+            }
             if (_body.IsValid) _body.Destroy();
             // Free referenced geometry (meshes) only after the body — and its shapes — are gone.
             if (_shapes != null)
@@ -269,8 +277,10 @@ namespace Box3D.Hybrid
             _body.SetType(ToNative(Type));
             _body.SetLinearDamping(LinearDamping);
             _body.SetAngularDamping(AngularDamping);
-            if (Type == Box3DBodyType.Kinematic) _world.AddKinematic(this);
-            else _world.RemoveKinematic(this);
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
+            if (Type == Box3DBodyType.Kinematic) IBox3DWorld.Get(this).AddBody(this);
+            else IBox3DWorld.Get(this).RemoveBody(this);
         }
 #endif
 

--- a/Box3D.Hybrid/Box3DDistanceJoint.cs
+++ b/Box3D.Hybrid/Box3DDistanceJoint.cs
@@ -69,7 +69,7 @@ namespace Box3D.Hybrid
                 def.DampingRatio = DampingRatio;
             }
 
-            _distance = World.World.CreateDistanceJoint(def);
+            _distance = IBox3DWorld.Get(this).PhysicsWorld.CreateDistanceJoint(def);
             return _distance;
         }
 

--- a/Box3D.Hybrid/Box3DExplosion.cs
+++ b/Box3D.Hybrid/Box3DExplosion.cs
@@ -42,7 +42,9 @@ namespace Box3D.Hybrid
             def.Radius = Radius;
             def.Falloff = Falloff;
             def.ImpulsePerArea = ImpulsePerArea;
-            Box3DWorld.Instance.World.Explode(def);
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
+            world.PhysicsWorld.Explode(def);
         }
 
         // Matches the Forces category icon color.

--- a/Box3D.Hybrid/Box3DFilterJoint.cs
+++ b/Box3D.Hybrid/Box3DFilterJoint.cs
@@ -14,7 +14,7 @@ namespace Box3D.Hybrid
             FilterJointDef def = FilterJointDef.Default;
             def.Base.BodyIdA = bodyA;
             def.Base.BodyIdB = bodyB;
-            return World.World.CreateFilterJoint(def);
+            return IBox3DWorld.Get(this).PhysicsWorld.CreateFilterJoint(def);
         }
     }
 }

--- a/Box3D.Hybrid/Box3DFixedJoint.cs
+++ b/Box3D.Hybrid/Box3DFixedJoint.cs
@@ -26,7 +26,7 @@ namespace Box3D.Hybrid
             def.LinearHertz = LinearHertz;
             def.AngularHertz = AngularHertz;
 
-            _weld = World.World.CreateWeldJoint(def);
+            _weld = IBox3DWorld.Get(this).PhysicsWorld.CreateWeldJoint(def);
             return _weld;
         }
 

--- a/Box3D.Hybrid/Box3DHingeJoint.cs
+++ b/Box3D.Hybrid/Box3DHingeJoint.cs
@@ -57,7 +57,7 @@ namespace Box3D.Hybrid
                 def.MaxMotorTorque = MaxMotorTorque;
             }
 
-            _hinge = World.World.CreateRevoluteJoint(def);
+            _hinge = IBox3DWorld.Get(this).PhysicsWorld.CreateRevoluteJoint(def);
             return _hinge;
         }
 

--- a/Box3D.Hybrid/Box3DJoint.cs
+++ b/Box3D.Hybrid/Box3DJoint.cs
@@ -21,9 +21,6 @@ namespace Box3D.Hybrid
 
         private Joint _joint;
 
-        /// <summary>The world owning this joint (valid after Start).</summary>
-        protected Box3DWorld World { get; private set; }
-
         /// <summary>The joint pivot in world space.</summary>
         protected Vector3 WorldAnchor => transform.TransformPoint(Anchor);
 
@@ -42,12 +39,9 @@ namespace Box3D.Hybrid
 
         private void Start()
         {
-            World = Box3DWorld.Instance;
-
             Box3DBody self = GetComponent<Box3DBody>();
             BodyId bodyB = self.Body.Id;
-            BodyId bodyA = ConnectedBody ? ConnectedBody.Body.Id : World.WorldAnchor.Id;
-
+            BodyId bodyA = ConnectedBody ? ConnectedBody.Body.Id : IBox3DWorld.Get(ConnectedBody).WorldAnchor.Id;
             _joint = CreateJoint(bodyA, bodyB);
 
             // box3d sets the collide-connected flag at joint creation but does NOT clear a contact

--- a/Box3D.Hybrid/Box3DMotorJoint.cs
+++ b/Box3D.Hybrid/Box3DMotorJoint.cs
@@ -43,7 +43,7 @@ namespace Box3D.Hybrid
             def.AngularDampingRatio = AngularDampingRatio;
             def.MaxSpringTorque = MaxTorque;
 
-            _motor = World.World.CreateMotorJoint(def);
+            _motor = IBox3DWorld.Get(this).PhysicsWorld.CreateMotorJoint(def);
             return _motor;
         }
 

--- a/Box3D.Hybrid/Box3DParallelJoint.cs
+++ b/Box3D.Hybrid/Box3DParallelJoint.cs
@@ -41,7 +41,7 @@ namespace Box3D.Hybrid
             def.DampingRatio = DampingRatio;
             def.MaxTorque = MaxTorque;
 
-            _parallel = World.World.CreateParallelJoint(def);
+            _parallel = IBox3DWorld.Get(this).PhysicsWorld.CreateParallelJoint(def);
             return _parallel;
         }
 

--- a/Box3D.Hybrid/Box3DRecorder.cs
+++ b/Box3D.Hybrid/Box3DRecorder.cs
@@ -27,17 +27,16 @@ namespace Box3D.Hybrid
         [SerializeField, Tooltip("Also save the capture here on stop (empty = don't save).")]
         private string SavePath = "";
 
-        private Box3DWorld _world;
+        private IBox3DWorld _world;
         private Recording _recording;
         private int _steps;
         private bool _isRecording;
 
         private void Start()
         {
-            _world = Box3DWorld.Instance;
-            if (!_world || !_world.World.IsValid) return;
-
-            if (_world.World.GetCounters().BodyCount == 0)
+            _world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(_world)) return;
+            if (_world.PhysicsWorld.GetCounters().BodyCount == 0)
             {
                 Debug.LogWarning("[Box3DRecorder] the Box3DWorld has 0 bodies — the recording will be empty. " +
                     "This recorder captures the component Box3DWorld; scenes that build physics via the raw API " +
@@ -46,7 +45,7 @@ namespace Box3D.Hybrid
             }
 
             _recording = Recording.Create();
-            _world.World.StartRecording(_recording);
+            _world.PhysicsWorld.StartRecording(_recording);
             _isRecording = true;
             _steps = 0;
         }
@@ -62,8 +61,8 @@ namespace Box3D.Hybrid
         [ContextMenu("Stop & Validate")]
         public void Stop()
         {
-            if (!_isRecording || !_world || !_world.World.IsValid) return;
-            _world.World.StopRecording();
+            if (!_isRecording || !_world.IsValid) return;
+            _world.PhysicsWorld.StopRecording();
             _isRecording = false;
             Debug.Log($"[Box3DRecorder] recorded {_steps} steps, {_recording.Size / 1024} KB.", this);
 
@@ -95,7 +94,7 @@ namespace Box3D.Hybrid
 
         private void OnDestroy()
         {
-            if (_isRecording && _world && _world.World.IsValid) _world.World.StopRecording();
+            if (_isRecording && _world.IsValid) _world.PhysicsWorld.StopRecording();
             if (_recording.IsCreated) _recording.Destroy();
         }
     }

--- a/Box3D.Hybrid/Box3DRope.cs
+++ b/Box3D.Hybrid/Box3DRope.cs
@@ -65,7 +65,6 @@ namespace Box3D.Hybrid
         [SerializeField, HideInInspector]
         private Vector3[] BakedPoints; // local space, captured by the editor's Bake button
 
-        private Box3DWorld _world;
         private Body[] _segments;
         private Joint[] _joints;
         private Body _startPin;    // static pin bodies, created only for unattached ends
@@ -100,19 +99,21 @@ namespace Box3D.Hybrid
             _line = GetComponent<LineRenderer>();
             _line.useWorldSpace = true;
 
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
+
             // Start (not Awake) so every Box3DBody the ends may attach to already exists.
-            if (Mode == RopeMode.Baked) BuildBaked();
-            else BuildDynamic();
+            if (Mode == RopeMode.Baked) BuildBaked(world);
+            else BuildDynamic(world);
         }
 
-        private void BuildBaked()
+        private void BuildBaked(IBox3DWorld world)
         {
             Vector3[] points = HasBake ? BakedToWorld() : ComputeSettledPoints();
             ApplyToLine(points);
             if (!BakedCollision || points.Length < 2) return;
 
-            _world = Box3DWorld.Instance;
-            _bakedBody = _world.World.CreateBody(BodyDef.Default); // static, identity — capsules in world coords
+            _bakedBody = world.PhysicsWorld.CreateBody(BodyDef.Default); // static, identity — capsules in world coords
             ShapeDef def = SegmentShapeDef();
             for (int i = 0; i < points.Length - 1; i++)
             {
@@ -125,10 +126,8 @@ namespace Box3D.Hybrid
             }
         }
 
-        private void BuildDynamic()
+        private void BuildDynamic(IBox3DWorld world)
         {
-            _world = Box3DWorld.Instance;
-
             // Spawn taut along the straight line between the ends. The slack lives in the joint
             // rest lengths, so the rope sags into place under gravity and drapes onto whatever it
             // meets — a pre-settled spawn would thread segments through scene geometry, because
@@ -143,6 +142,7 @@ namespace Box3D.Hybrid
             _halfSegment = restLength * 0.5f;
 
             _segments = new Body[Segments];
+            if (world == null || !world.IsValid) return;
             for (int i = 0; i < Segments; i++)
             {
                 float3 a = nodes[i];
@@ -158,7 +158,7 @@ namespace Box3D.Hybrid
                 // Thin, fast-moving segments tunnel through other objects without continuous
                 // collision — bullet mode keeps the rope reacting to everything it sweeps past.
                 bodyDef.IsBullet = true;
-                _segments[i] = _world.World.CreateBody(bodyDef);
+                _segments[i] = world.PhysicsWorld.CreateBody(bodyDef);
 
                 ShapeDef shapeDef = SegmentShapeDef();
                 float cap = Mathf.Max(0.001f, _halfSegment - Radius);
@@ -175,15 +175,15 @@ namespace Box3D.Hybrid
             // Chain: each shared node links the +Z tip of one segment to the -Z tip of the next.
             for (int i = 1; i < Segments; i++)
             {
-                joints.Add(Link(_segments[i - 1], new float3(0f, 0f, _halfSegment),
+                joints.Add(Link(world, _segments[i - 1], new float3(0f, 0f, _halfSegment),
                                 _segments[i], new float3(0f, 0f, -_halfSegment)));
             }
 
             // Ends: a Box3DBody at the endpoint (rope follows/pulls it), else a static world pin.
             Box3DBody startBody = FindStartAttachment();
             Box3DBody endBody = FindEndAttachment();
-            joints.Add(AttachEnd(_segments[0], new float3(0f, 0f, -_halfSegment), nodes[0], startBody, ref _startPin));
-            joints.Add(AttachEnd(_segments[Segments - 1], new float3(0f, 0f, _halfSegment), nodes[Segments], endBody, ref _endPin));
+            joints.Add(AttachEnd(world, _segments[0], new float3(0f, 0f, -_halfSegment), nodes[0], startBody, ref _startPin));
+            joints.Add(AttachEnd(world, _segments[Segments - 1], new float3(0f, 0f, _halfSegment), nodes[Segments], endBody, ref _endPin));
 
             // The attach joints already skip their own pair (collide-connected is off), but the
             // rope's other segments would still hit the attached body — and the near-anchor ones
@@ -191,8 +191,8 @@ namespace Box3D.Hybrid
             // attached body unless collision was explicitly requested.
             if (!CollideWithAttached)
             {
-                if (startBody) FilterAgainst(joints, startBody.Body, _segments[0]);
-                if (endBody) FilterAgainst(joints, endBody.Body, _segments[Segments - 1]);
+                if (startBody) FilterAgainst(world, joints, startBody.Body, _segments[0]);
+                if (endBody) FilterAgainst(world, joints, endBody.Body, _segments[Segments - 1]);
             }
 
             _joints = joints.ToArray();
@@ -211,7 +211,7 @@ namespace Box3D.Hybrid
             return def;
         }
 
-        private void FilterAgainst(List<Joint> joints, Body attached, Body alreadyJointed)
+        private void FilterAgainst(IBox3DWorld world, List<Joint> joints, Body attached, Body alreadyJointed)
         {
             foreach (Body segment in _segments)
             {
@@ -219,21 +219,21 @@ namespace Box3D.Hybrid
                 FilterJointDef def = FilterJointDef.Default;
                 def.Base.BodyIdA = attached.Id;
                 def.Base.BodyIdB = segment.Id;
-                joints.Add(_world.World.CreateFilterJoint(def));
+                joints.Add(world.PhysicsWorld.CreateFilterJoint(def));
             }
         }
 
-        private Joint Link(Body a, float3 localA, Body b, float3 localB)
+        private Joint Link(IBox3DWorld world, Body a, float3 localA, Body b, float3 localB)
         {
             SphericalJointDef def = SphericalJointDef.Default;
             def.Base.BodyIdA = a.Id;
             def.Base.BodyIdB = b.Id;
             def.Base.LocalFrameA = new B3Transform { Position = localA, Rotation = quaternion.identity };
             def.Base.LocalFrameB = new B3Transform { Position = localB, Rotation = quaternion.identity };
-            return _world.World.CreateSphericalJoint(def);
+            return world.PhysicsWorld.CreateSphericalJoint(def);
         }
 
-        private Joint AttachEnd(Body segment, float3 segmentLocal, float3 worldNode, Box3DBody attach, ref Body pin)
+        private Joint AttachEnd(IBox3DWorld world, Body segment, float3 segmentLocal, float3 worldNode, Box3DBody attach, ref Body pin)
         {
             Body other;
             float3 otherLocal;
@@ -248,11 +248,11 @@ namespace Box3D.Hybrid
             {
                 BodyDef pinDef = BodyDef.Default; // static
                 pinDef.Position = worldNode;
-                pin = _world.World.CreateBody(pinDef);
+                pin = world.PhysicsWorld.CreateBody(pinDef);
                 other = pin;
                 otherLocal = float3.zero;
             }
-            return Link(other, otherLocal, segment, segmentLocal);
+            return Link(world, other, otherLocal, segment, segmentLocal);
         }
 
         private void LateUpdate()
@@ -307,14 +307,8 @@ namespace Box3D.Hybrid
         {
             var points = new Vector3[Segments + 1];
             SettleCurve(points, StartWorld, EndWorld,
-                Vector3.Distance(StartWorld, EndWorld) * (1f + Slack) / Segments, SceneGravity(), 240);
+                Vector3.Distance(StartWorld, EndWorld) * (1f + Slack) / Segments, IBox3DWorld.GetSceneGravity(this), 240);
             return points;
-        }
-
-        internal Vector3 SceneGravity()
-        {
-            var world = Application.isPlaying && _world ? _world : FindAnyObjectByType<Box3DWorld>();
-            return world ? world.GravityVector : new Vector3(0f, -9.81f, 0f);
         }
 
         internal float SettledSegmentLength()

--- a/Box3D.Hybrid/Box3DRopePreview.cs
+++ b/Box3D.Hybrid/Box3DRopePreview.cs
@@ -27,7 +27,7 @@ namespace Box3D.Hybrid
             _nodes = new Vector3[rope.SegmentCount + 1];
 
             WorldDef worldDef = WorldDef.Default;
-            worldDef.Gravity = rope.SceneGravity();
+            worldDef.Gravity = IBox3DWorld.GetSceneGravity(rope);
             _world = World.Create(worldDef);
 
             ReplicateScene();

--- a/Box3D.Hybrid/Box3DShape.cs
+++ b/Box3D.Hybrid/Box3DShape.cs
@@ -84,12 +84,12 @@ namespace Box3D.Hybrid
             // A body on this GameObject or an ancestor will gather and attach this shape (including
             // as a compound child). Otherwise the shape is an orphan → give it a static body.
             if (GetComponentInParent<Box3DBody>()) return;
-
-            Box3DWorld world = Box3DWorld.Instance;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
             BodyDef def = BodyDef.Default; // static by default
             def.Position = transform.position;
             def.Rotation = transform.rotation;
-            _ownBody = world.World.CreateBody(def);
+            _ownBody = world.PhysicsWorld.CreateBody(def);
             AttachTo(_ownBody, float3.zero, quaternion.identity, transform.lossyScale);
         }
 

--- a/Box3D.Hybrid/Box3DSliderJoint.cs
+++ b/Box3D.Hybrid/Box3DSliderJoint.cs
@@ -51,7 +51,7 @@ namespace Box3D.Hybrid
                 def.MaxMotorForce = MaxMotorForce;
             }
 
-            _slider = World.World.CreatePrismaticJoint(def);
+            _slider = IBox3DWorld.Get(this).PhysicsWorld.CreatePrismaticJoint(def);
             return _slider;
         }
 

--- a/Box3D.Hybrid/Box3DStatsHud.cs
+++ b/Box3D.Hybrid/Box3DStatsHud.cs
@@ -29,7 +29,7 @@ namespace Box3D.Hybrid
         [SerializeField, Range(10, 28)]
         private int FontSize = 14;
 
-        private Box3DWorld _world;
+        private IBox3DWorld _world;
         private bool _worldSearched;
         private Profile _profile;
         private Counters _counters;
@@ -47,18 +47,17 @@ namespace Box3D.Hybrid
             // One-shot acquisition: Box3DWorld.Instance scene-searches and AUTO-CREATES a world
             // when none exists — retrying every frame would make a diagnostics overlay respawn
             // physics after the world it was watching died.
-            if (!_world)
+            if (_world == null)
             {
                 if (_worldSearched) return;
                 _worldSearched = true;
-                _world = Box3DWorld.Instance;
+                _world = IBox3DWorld.Get(this);
             }
-            World world = _world ? _world.World : default;
-            if (!world.IsValid) return;
+            if (!IBox3DWorld.Validate(_world)) return;
 
-            _profile = world.GetProfile();
-            _counters = world.GetCounters();
-            _awakeBodies = world.GetAwakeBodyCount();
+            _profile = _world.PhysicsWorld.GetProfile();
+            _counters = _world.PhysicsWorld.GetCounters();
+            _awakeBodies = _world.PhysicsWorld.GetAwakeBodyCount();
 
             // Smooth the noisy per-step values so they're readable.
             _stepMs = Mathf.Lerp(_stepMs, _profile.Step, 0.1f);
@@ -72,7 +71,7 @@ namespace Box3D.Hybrid
 
         private void OnGUI()
         {
-            if (!Visible || !_world || string.IsNullOrEmpty(_content.text)) return;
+            if (!Visible || _world == null || string.IsNullOrEmpty(_content.text)) return;
 
             EnsureStyle();
             Vector2 size = _style.CalcSize(_content);

--- a/Box3D.Hybrid/Box3DVisualReplayer.cs
+++ b/Box3D.Hybrid/Box3DVisualReplayer.cs
@@ -32,7 +32,6 @@ namespace Box3D.Hybrid
         private const int MaxCatchUpSteps = 8;
 
         private ReplayPlayer _player;
-        private Box3DWorld _world;
         private Transform[] _targets; // replay body index -> scene transform (null = unmapped / hole)
         private Body[] _replayBodies; // replay body handles, resolved once at mapping time
         private bool _isPlaying;
@@ -50,12 +49,11 @@ namespace Box3D.Hybrid
         private void Start()
         {
             if (string.IsNullOrEmpty(LoadPath)) return;
-
             // Pause live physics right away so the scene doesn't simulate before the replay takes over,
             // then defer the load one frame: objects built in other components' Start() (like a spawned
             // car) don't exist yet here, but they will by the first Update.
-            _world = Box3DWorld.Instance;
-            if (_world) _world.Paused = true;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (IBox3DWorld.Validate(world)) world.IsPaused = true;
             _pendingLoad = true;
         }
 
@@ -93,8 +91,8 @@ namespace Box3D.Hybrid
         private void BuildMapping()
         {
             // Pause live physics so it doesn't fight the replayed transforms.
-            _world = Box3DWorld.Instance;
-            if (_world) _world.Paused = true;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
 
             // Group scene objects by their (recorded) body name — read from the live body so it matches
             // the recording's truncation exactly.
@@ -222,7 +220,8 @@ namespace Box3D.Hybrid
         private void Unload()
         {
             if (_player.IsCreated) _player.Destroy();
-            if (_world) _world.Paused = false;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (IBox3DWorld.Validate(world)) world.IsPaused = false;
             _isPlaying = false;
             _targets = null;
         }

--- a/Box3D.Hybrid/Box3DWaterVolume.cs
+++ b/Box3D.Hybrid/Box3DWaterVolume.cs
@@ -71,7 +71,6 @@ namespace Box3D.Hybrid
         private static readonly Color ZoneGizmoColor = new Color(0.25f, 0.6f, 0.9f, 0.9f);
         private static readonly Color SurfaceGizmoColor = new Color(0.25f, 0.6f, 0.9f, 0.25f);
 
-        private Box3DWorld _world;
         private float _lastSurfaceY = float.NaN;
         private bool _warnedTruncated;
 
@@ -142,16 +141,13 @@ namespace Box3D.Hybrid
             return Mathf.Clamp(surface, centerY - halfY, centerY + halfY);
         }
 
-        private void Awake()
-        {
-            _world = Box3DWorld.Instance;
-        }
-
         // Runs after Box3DWorld's step (it uses DefaultExecutionOrder(-100)), so forces land on the
         // next step — a constant one-step latency, the same every frame.
         private void FixedUpdate()
         {
-            if (!_world || _world.Paused || !_world.World.IsValid) return;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
+            if (world.IsPaused) return;
             if (Fill <= 0f)
             {
                 FlushSubmerged();
@@ -175,14 +171,14 @@ namespace Box3D.Hybrid
                 UpperBound = new float3(center.x + half.x, surfaceY + (waves ? WaveAmplitude : 0f), center.z + half.z),
             };
 
-            int count = _world.World.OverlapAABB(water, QueryFilter.Default, _overlap);
+            int count = world.PhysicsWorld.OverlapAABB(water, QueryFilter.Default, _overlap);
             if (count == _overlap.Length && !_warnedTruncated)
             {
                 _warnedTruncated = true;
                 Debug.LogWarning($"[Box3DWaterVolume] more than {_overlap.Length} shapes in the water — extras get no buoyancy this step.", this);
             }
 
-            float3 gravity = (float3)_world.GravityVector;
+            float3 gravity = (float3)world.Gravity;
             float3 current = (float3)Current;
 
             for (int i = 0; i < count; i++)

--- a/Box3D.Hybrid/Box3DWheelJoint.cs
+++ b/Box3D.Hybrid/Box3DWheelJoint.cs
@@ -1,3 +1,4 @@
+
 using Unity.Mathematics;
 using UnityEngine;
 
@@ -109,7 +110,7 @@ namespace Box3D.Hybrid
             def.LowerSteeringLimit = -math.radians(MaxSteerAngle);
             def.UpperSteeringLimit = math.radians(MaxSteerAngle);
 
-            _wheel = World.World.CreateWheelJoint(def);
+            _wheel = IBox3DWorld.Get(this).PhysicsWorld.CreateWheelJoint(def);
             return _wheel;
         }
 

--- a/Box3D.Hybrid/Box3DWind.cs
+++ b/Box3D.Hybrid/Box3DWind.cs
@@ -31,7 +31,6 @@ namespace Box3D.Hybrid
         [SerializeField, Range(0f, 1f), Tooltip("How hard this wind grips the scene's Box3DWater: fluid at the surface (and foam) gets Strength × this as acceleration in m/s², fading to nothing below the surface. 0 = water ignores this wind.")]
         private float WaterInfluence = 0.25f;
 
-        private Box3DWorld _world;
         private Box3DWater _water;
         private bool _waterSearched;
         private float _currentStrength;
@@ -42,7 +41,6 @@ namespace Box3D.Hybrid
 
         private void Awake()
         {
-            _world = Box3DWorld.Instance;
             _currentStrength = Strength;
         }
 
@@ -50,7 +48,9 @@ namespace Box3D.Hybrid
         // next step — a constant one-step latency, the same every frame.
         private void FixedUpdate()
         {
-            if (!_world || _world.Paused || !_world.World.IsValid) return;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world)) return;
+            if (world.IsPaused) return;
 
             _currentStrength = Strength;
             if (GustAmplitude > 0f && GustFrequency > 0f)
@@ -71,7 +71,7 @@ namespace Box3D.Hybrid
                 UpperBound = (float3)transform.position + worldExtents,
             };
 
-            int count = _world.World.OverlapAABB(aabb, QueryFilter.Default, _overlap);
+            int count = world.PhysicsWorld.OverlapAABB(aabb, QueryFilter.Default, _overlap);
             _bodies.Clear();
             for (int i = 0; i < count; i++)
             {

--- a/Box3D.Hybrid/Box3DWorld.cs
+++ b/Box3D.Hybrid/Box3DWorld.cs
@@ -82,18 +82,21 @@ namespace Box3D.Hybrid
 
 #nullable enable
         private static Box3DWorld _instance;
-        public static IBox3DWorld? GetInstance(UnityEngine.SceneManagement.Scene? scene, MonoBehaviour? requester)
+        public static IBox3DWorld? Instance
         {
-            if (!_instance)
+            get
             {
-                _instance = FindAnyObjectByType<Box3DWorld>();
                 if (!_instance)
                 {
-                    if (Application.isPlaying)
-                        _instance = new GameObject("Box3D World").AddComponent<Box3DWorld>();
+                    _instance = FindAnyObjectByType<Box3DWorld>();
+                    if (!_instance)
+                    {
+                        if (Application.isPlaying)
+                            _instance = new GameObject("Box3D World").AddComponent<Box3DWorld>();
+                    }
                 }
+                return _instance;
             }
-            return _instance;
         }
 #nullable disable
 

--- a/Box3D.Hybrid/Box3DWorld.cs
+++ b/Box3D.Hybrid/Box3DWorld.cs
@@ -1,22 +1,33 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using log4net.DateFormatter;
+using Unity.Scripting.LifecycleManagement;
+using Unity.VectorGraphics;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Box3D.Hybrid
 {
+
+
+
+
     /// <summary>Scene-level owner of a Box3D simulation world. Steps from FixedUpdate, pushes
     /// kinematic bodies before the step and syncs moved bodies back after. Auto-created on demand
-    /// (like Unity's single physics world); place one explicitly to tune gravity, sub-steps, or
+    /// (like Unity's single physics world); place one explicitly to tune Gravity, sub-steps, or
     /// worker count.</summary>
     [Icon("Packages/com.suvitruf.box3d/Box3D.Hybrid.Editor/Icons/Box3DWorld.png")]
     [AddComponentMenu("Box3D/World")]
     [DefaultExecutionOrder(-100)]
     [DisallowMultipleComponent]
-    public class Box3DWorld : MonoBehaviour
+    [NoAutoStaticsCleanup]
+
+
+    public class Box3DWorld : MonoBehaviour, IBox3DWorld
     {
         [SerializeField, Tooltip("Gravity vector applied to every dynamic body.")]
-        private Vector3 Gravity = new Vector3(0f, -9.81f, 0f);
+        private Vector3 Gravity = IBox3DWorld.DefaultGravity;
 
         [SerializeField, Min(1), Tooltip("Solver sub-steps per step. Higher = stiffer, slower.")]
         private int SubStepCount = 4;
@@ -36,26 +47,57 @@ namespace Box3D.Hybrid
         // bodies sync back through move events — which report only bodies that actually moved — so
         // they never appear here. Bodies map back to their component through a GCHandle in userData,
         // so no all-bodies list is kept.
-        private readonly List<Box3DBody> _kinematicBodies = new List<Box3DBody>();
+        private readonly List<Box3DBody> _kinematicBodies = new();
 
         private World _world;
         private Body _anchor;
+
+        World IBox3DWorld.PhysicsWorld => _world;
+        Vector3 IBox3DWorld.Gravity
+        {
+            get => this.Gravity;
+            set { }
+        }
+
+        Vector3 IBox3DWorld.GravityDirection
+        {
+            get
+            {
+                Vector3 absolute = new(Mathf.Abs(this.Gravity.x), Mathf.Abs(this.Gravity.y), Mathf.Abs(this.Gravity.z));
+                return absolute.normalized;
+            }
+        }
+
+        private bool _paused;
+        bool IBox3DWorld.IsPaused
+        {
+            get => _paused;
+            set
+            {
+                _paused = value;
+            }
+        }
+
+        bool IBox3DWorld.IsValid => _world != null && _world.IsValid;
+
+#nullable enable
         private static Box3DWorld _instance;
+        public static IBox3DWorld? GetInstance(UnityEngine.SceneManagement.Scene? scene, MonoBehaviour? requester)
+        {
+            if (!_instance)
+            {
+                _instance = FindAnyObjectByType<Box3DWorld>();
+                if (!_instance)
+                {
+                    if (Application.isPlaying)
+                        _instance = new GameObject("Box3D World").AddComponent<Box3DWorld>();
+                }
+            }
+            return _instance;
+        }
+#nullable disable
 
-        /// <summary>The underlying Box3D world (valid after this component is enabled).</summary>
-        public World World => _world;
-
-        /// <summary>When true, the world stops stepping (bodies stay put). The visual replayer sets this
-        /// so live physics doesn't fight the replayed transforms.</summary>
-        public bool Paused { get; set; }
-
-        /// <summary>The configured gravity vector (readable without a live world — the rope's
-        /// editor preview settles under the same gravity the simulation will use).</summary>
-        public Vector3 GravityVector => Gravity;
-
-        /// <summary>A shared static body at the origin, used as the fixed endpoint for joints whose
-        /// connected body is null (like Unity's null connectedBody = attach to the world).</summary>
-        public Body WorldAnchor
+        Body IBox3DWorld.WorldAnchor
         {
             get
             {
@@ -65,23 +107,6 @@ namespace Box3D.Hybrid
                     _anchor = _world.CreateBody(BodyDef.Default); // static at origin
                 }
                 return _anchor;
-            }
-        }
-
-        /// <summary>The active world component, creating one if the scene has none.</summary>
-        public static Box3DWorld Instance
-        {
-            get
-            {
-                if (!_instance)
-                {
-                    _instance = FindAnyObjectByType<Box3DWorld>();
-                    if (!_instance)
-                    {
-                        _instance = new GameObject("Box3D World").AddComponent<Box3DWorld>();
-                    }
-                }
-                return _instance;
             }
         }
 
@@ -98,9 +123,8 @@ namespace Box3D.Hybrid
         private void EnsureCreated()
         {
             if (_world.IsValid) return;
-
             WorldDef def = WorldDef.Default;
-            def.Gravity = Gravity;
+            def.Gravity = this.Gravity;
             def.WorkerCount = (uint)(WorkerCount > 0 ? WorkerCount : Mathf.Max(1, SystemInfo.processorCount / 2));
             _world = World.Create(def);
         }
@@ -111,23 +135,23 @@ namespace Box3D.Hybrid
             // Push Inspector edits to the live world during play. SubStepCount and DebugDraw are
             // read every frame anyway; WorkerCount is baked at world creation.
             if (!Application.isPlaying || !_world.IsValid) return;
-            _world.SetGravity(Gravity);
+            _world.SetGravity(this.Gravity);
         }
 #endif
 
-        internal void AddKinematic(Box3DBody body)
+        void IBox3DWorld.AddBody(Box3DBody body)
         {
             if (!_kinematicBodies.Contains(body)) _kinematicBodies.Add(body);
         }
 
-        internal void RemoveKinematic(Box3DBody body)
+        void IBox3DWorld.RemoveBody(Box3DBody body)
         {
             _kinematicBodies.Remove(body);
         }
 
         private void FixedUpdate()
         {
-            if (Paused || !_world.IsValid) return;
+            if (_paused || !_world.IsValid) return;
 
             float deltaTime = Time.fixedDeltaTime;
             for (int i = 0; i < _kinematicBodies.Count; i++)
@@ -156,13 +180,23 @@ namespace Box3D.Hybrid
                 Box3DBody bodyB = BodyFromShape(hitEvent.ShapeIdB);
                 if (bodyA && bodyA.WantsHits)
                 {
-                    bodyA.DispatchHit(new Box3DHit { Point = (Vector3)hitEvent.Point, Direction = -hitEvent.Normal,
-                        ApproachSpeed = hitEvent.ApproachSpeed, OtherBody = bodyB });
+                    bodyA.DispatchHit(new Box3DHit
+                    {
+                        Point = (Vector3)hitEvent.Point,
+                        Direction = -hitEvent.Normal,
+                        ApproachSpeed = hitEvent.ApproachSpeed,
+                        OtherBody = bodyB
+                    });
                 }
                 if (bodyB && bodyB.WantsHits)
                 {
-                    bodyB.DispatchHit(new Box3DHit { Point = (Vector3)hitEvent.Point, Direction = hitEvent.Normal,
-                        ApproachSpeed = hitEvent.ApproachSpeed, OtherBody = bodyA });
+                    bodyB.DispatchHit(new Box3DHit
+                    {
+                        Point = (Vector3)hitEvent.Point,
+                        Direction = hitEvent.Normal,
+                        ApproachSpeed = hitEvent.ApproachSpeed,
+                        OtherBody = bodyA
+                    });
                 }
             }
         }
@@ -187,21 +221,21 @@ namespace Box3D.Hybrid
             }
         }
 
-        // Matches the world component's purple icon so the arrow reads as "the world's gravity".
+        // Matches the world component's purple icon so the arrow reads as "the world's Gravity".
         private static readonly Color GravityGizmoColor = new Color(0.75f, 0.53f, 0.92f, 0.95f);
 
         private void OnDrawGizmosSelected()
         {
-            float magnitude = Gravity.magnitude;
-            if (magnitude < 1e-4f) return; // zero gravity — nothing to point at
+            float magnitude = this.Gravity.magnitude;
+            if (magnitude < 1e-4f) return; // zero Gravity — nothing to point at
 
             Vector3 origin = transform.position;
-            Vector3 dir = Gravity / magnitude;
+            Vector3 dir = this.Gravity / magnitude;
             // Shaft length tracks strength (1 g ≈ 1.5 m), clamped so extreme values stay readable.
             float length = Mathf.Clamp(1.5f * magnitude / 9.81f, 0.4f, 4f);
             Vector3 tip = origin + dir * length;
 
-            // A basis perpendicular to the arrow for the head fins (gravity is usually straight
+            // A basis perpendicular to the arrow for the head fins (Gravity is usually straight
             // down, where Vector3.up is degenerate — fall back to right).
             Vector3 side = Vector3.Cross(dir, Vector3.up);
             if (side.sqrMagnitude < 1e-4f) side = Vector3.Cross(dir, Vector3.right);

--- a/Box3D.Hybrid/IBox3DWorld.cs
+++ b/Box3D.Hybrid/IBox3DWorld.cs
@@ -1,0 +1,146 @@
+using Unity.Scripting.LifecycleManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+
+namespace Box3D.Hybrid
+{
+
+#nullable enable
+
+    /// <summary>
+    /// This delegate is used by the IBox3DWorld interface to provide an instance of itself anonymously. 
+    /// Useful for game management logic in cases where you'd like to supply your own IBox3DWorld instance
+    /// to internal systems, bypassing the lazy instantiation done by the Box3DWorld monobehaviour.
+    /// This also allows you to juggle multiple world instances simultaneously, should that be required.
+    /// </summary>
+    public delegate IBox3DWorld? WorldProvider(Scene? scene, MonoBehaviour? requester);
+
+    /// <summary>
+    /// The Box3DWorld is responsible for tracking and updating Box3D bodies.
+    /// Box3DWorld and Box3DEditorSimulation both provide a template implementation for IBox3DWorld
+    /// </summary>
+    public interface IBox3DWorld
+    {
+
+        public static bool Validate(IBox3DWorld? world)
+        {
+            if (world != null && world.IsValid) return true;
+            Debug.LogError("An operation failed to proceed due to an invalidated IBox3DWorld");
+            return false;
+        }
+
+
+        /// <summary>
+        /// The provider supplies the IBox3DWorld instance to all internal systems.
+        /// Note that this delegate is initially set to Box3DWorld's singleton
+        /// getter, so the default reference returned by invoking Get() will 
+        /// always be the singleton stored in Box3DWorld.
+        /// </summary>
+        [NoAutoStaticsCleanup]
+        private static WorldProvider _provider = Box3DWorld.GetInstance;
+
+        /// <summary>
+        /// Gets the IBox3DWorld instance for the given scene and requester.
+        /// </summary>
+        /// <returns></returns>
+        public static IBox3DWorld? Get()
+        {
+            return _provider.Invoke(SceneManager.GetActiveScene(), null);
+        }
+
+        /// <summary>
+        /// Gets the IBox3DWorld instance for the given scene and requester.
+        /// </summary>
+        /// <returns></returns>
+        public static IBox3DWorld? Get(MonoBehaviour requester)
+        {
+            if (requester == null) return Get();
+            return _provider.Invoke(requester.gameObject.scene, requester);
+        }
+
+        /// <summary>
+        /// Gets the IBox3DWorld instance for the given scene and requester.
+        /// </summary>
+        /// <returns></returns>
+        public static IBox3DWorld? Get(Scene scene, Box3DBody body)
+        {
+            return _provider.Invoke(scene, body);
+        }
+
+        /// <summary>
+        /// Manually assigns the WorldProvider delegate. This delegate
+        /// allows API users to specify a custom IBox3DWorld implementation
+        /// to defer all operations towards. The default WorldProvider
+        /// invokes the singleton getter located in the Box3DWorld monobehaviour.
+        /// </summary>
+        /// <returns></returns>
+        public static void AssignProvider(WorldProvider? provider)
+        {
+            if (provider == null) _provider = Box3DWorld.GetInstance;
+            else _provider = provider;
+        }
+
+        [NoAutoStaticsCleanup]
+        public static Vector3 DefaultGravity = new(0, -9.81f, 0);
+
+        /// <summary>
+        /// Gets the current gravity vector belonging to the scene. This method can be safely
+        /// invoked outside of playmode for editor-time visualization.
+        /// </summary>
+        /// <returns></returns>
+        public static Vector3 GetSceneGravity(MonoBehaviour? requester)
+        {
+#pragma warning disable CS8629
+            return GetSceneGravityOrDefault(requester, DefaultGravity).Value;
+#pragma warning restore CS8629
+        }
+
+        /// <summary>
+        /// Gets the current gravity vector belonging to the scene. This method can be safely
+        /// invoked outside of playmode for editor-time visualization.
+        /// </summary>
+        /// <returns></returns>
+        public static Vector3? GetSceneGravityOrDefault(MonoBehaviour? requester, in Vector3? defaultGravity)
+        {
+            if (!Application.isPlaying) return DefaultGravity;
+            IBox3DWorld? world = IBox3DWorld.Get(requester);
+            return world == null || !world.IsValid ? defaultGravity : world.Gravity;
+        }
+#nullable disable
+
+
+        /// <summary>The underlying Box3D world.</summary>
+        public abstract Box3D.World PhysicsWorld { get; }
+
+        /// <summary>
+        /// The configured gravity vector 
+        /// </summary>
+        public abstract Vector3 Gravity { get; set; }
+
+        /// <summary>
+        /// A normalized, absolute vector pointing along the axis of gravity.
+        /// </summary>
+        public abstract Vector3 GravityDirection { get; }
+
+        /// <summary>When true, the world stops stepping (bodies stay put). The visual replayer sets this
+        /// so live physics doesn't fight the replayed transforms.</summary>
+        public abstract bool IsPaused { get; set; }
+
+        public abstract bool IsValid { get; }
+
+        /// <summary>A shared static body at the origin, used as the fixed endpoint for joints whose
+        /// connected body is null (like Unity's null connectedBody = attach to the world).</summary>
+        public abstract Box3D.Body WorldAnchor { get; }
+
+        /// <summary>
+        /// To be called internally by bodies to add themselves to the world during initialization
+        /// </summary>
+        abstract void AddBody(Box3DBody body);
+
+        /// <summary>
+        /// To be called internally by bodies to remove themselves from the world during destruction
+        /// </summary>
+        abstract void RemoveBody(Box3DBody body);
+    }
+}

--- a/Box3D.Hybrid/IBox3DWorld.cs
+++ b/Box3D.Hybrid/IBox3DWorld.cs
@@ -38,7 +38,7 @@ namespace Box3D.Hybrid
         /// always be the singleton stored in Box3DWorld.
         /// </summary>
         [NoAutoStaticsCleanup]
-        private static WorldProvider _provider = Box3DWorld.GetInstance;
+        private static WorldProvider _provider = (scene, requester) => { return Box3DWorld.Instance; };
 
         /// <summary>
         /// Gets the IBox3DWorld instance for the given scene and requester.
@@ -77,7 +77,7 @@ namespace Box3D.Hybrid
         /// <returns></returns>
         public static void AssignProvider(WorldProvider? provider)
         {
-            if (provider == null) _provider = Box3DWorld.GetInstance;
+            if (provider == null) _provider = (scene, requester) => { return Box3DWorld.Instance; };
             else _provider = provider;
         }
 

--- a/Box3D.Hybrid/IBox3DWorld.cs.meta
+++ b/Box3D.Hybrid/IBox3DWorld.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 276b11e6d9863d441a1b2cae83fa860d

--- a/Box3D.Hybrid/Water/Box3DWater.cs
+++ b/Box3D.Hybrid/Water/Box3DWater.cs
@@ -114,7 +114,6 @@ namespace Box3D.Hybrid
         private const float ImpulseScale = 256f;   // fixed-point scale used by the compute kernels
         private const float RestDensity = 1000f;
 
-        private Box3DWorld _world;
         private ComputeShader _compute;
         private Box3DWaterRenderer _renderer;
 
@@ -208,7 +207,6 @@ namespace Box3D.Hybrid
                 return;
             }
 
-            _world = Box3DWorld.Instance;
             ComputeShader source = Resources.Load<ComputeShader>("Box3D/Box3DWaterSim");
             if (!source)
             {
@@ -372,16 +370,16 @@ namespace Box3D.Hybrid
 
             int n = 0;
             for (int x = 0; x < counts.x && n < _capacity; x++)
-            for (int y = 0; y < counts.y && n < _capacity; y++)
-            for (int z = 0; z < counts.z && n < _capacity; z++)
-            {
-                float3 local = -half + spacing * 0.5f + new float3(x, y, z) * spacing
-                               + rng.NextFloat3(-0.02f, 0.02f) * spacing;
-                float3 world = transform.TransformPoint((Vector3)local);
-                _spawnPositions[n] = new float4(world, 1f);
-                _spawnVelocities[n] = float4.zero;
-                n++;
-            }
+                for (int y = 0; y < counts.y && n < _capacity; y++)
+                    for (int z = 0; z < counts.z && n < _capacity; z++)
+                    {
+                        float3 local = -half + spacing * 0.5f + new float3(x, y, z) * spacing
+                                       + rng.NextFloat3(-0.02f, 0.02f) * spacing;
+                        float3 world = transform.TransformPoint((Vector3)local);
+                        _spawnPositions[n] = new float4(world, 1f);
+                        _spawnVelocities[n] = float4.zero;
+                        n++;
+                    }
 
             _positions.SetData(_spawnPositions, 0, 0, n);
             _velocities.SetData(_spawnVelocities, 0, 0, n);
@@ -514,12 +512,14 @@ namespace Box3D.Hybrid
 
         private void FixedUpdate()
         {
-            if (_positions == null || !_world || _world.Paused || !_world.World.IsValid) return;
+            if (_positions == null) return;
+            IBox3DWorld world = IBox3DWorld.Get(this);
+            if (!IBox3DWorld.Validate(world) || world.IsPaused) return;
 
             ApplyFinishedReadbacks();
             if (_activeRange == 0) return;
 
-            GatherColliders();
+            GatherColliders(world);
 
             float dt = Time.fixedDeltaTime / Substeps;
             float h = SmoothingRadius;
@@ -532,7 +532,7 @@ namespace Box3D.Hybrid
             _compute.SetInt(ShaderIds.ColliderCount, _colliderCount);
             _compute.SetFloat(ShaderIds.DeltaTime, dt);
             _compute.SetFloat(ShaderIds.InvDeltaTime, 1f / dt);
-            _compute.SetVector(ShaderIds.Gravity, (Vector3)_world.GravityVector * GravityScale);
+            _compute.SetVector(ShaderIds.Gravity, world.Gravity * GravityScale);
             _compute.SetFloat(ShaderIds.ParticleRadius, ParticleRadius);
             _compute.SetFloat(ShaderIds.SmoothingRadius, h);
             _compute.SetFloat(ShaderIds.RestDensity, RestDensity);
@@ -579,7 +579,7 @@ namespace Box3D.Hybrid
             if (TwoWayCoupling && _bodyCount > 0) RequestReadback();
         }
 
-        private void GatherColliders()
+        private void GatherColliders(IBox3DWorld world)
         {
             PruneDeadTerrains();
 
@@ -600,7 +600,7 @@ namespace Box3D.Hybrid
                 UpperBound = center + (float3)(BoundsSize * 0.5f) + margin,
             };
 
-            int shapeCount = _world.World.OverlapAABB(aabb, filter, _overlap);
+            int shapeCount = world.PhysicsWorld.OverlapAABB(aabb, filter, _overlap);
             _colliderCount = 0;
             _bodyCount = 0;
             _bodySlots.Clear();
@@ -616,58 +616,58 @@ namespace Box3D.Hybrid
                 switch (shape.GetShapeType())
                 {
                     case ShapeType.Sphere:
-                    {
-                        Sphere s = shape.GetSphere();
-                        col.Type = 0;
-                        col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, s.Center), 0f);
-                        col.Data = new float4(s.Radius, 0f, 0f, 0f);
-                        break;
-                    }
+                        {
+                            Sphere s = shape.GetSphere();
+                            col.Type = 0;
+                            col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, s.Center), 0f);
+                            col.Data = new float4(s.Radius, 0f, 0f, 0f);
+                            break;
+                        }
                     case ShapeType.Capsule:
-                    {
-                        Capsule c = shape.GetCapsule();
-                        col.Type = 1;
-                        col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, c.Center1), 0f);
-                        col.Data = new float4(tf.Position + math.rotate(tf.Rotation, c.Center2), c.Radius);
-                        break;
-                    }
+                        {
+                            Capsule c = shape.GetCapsule();
+                            col.Type = 1;
+                            col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, c.Center1), 0f);
+                            col.Data = new float4(tf.Position + math.rotate(tf.Rotation, c.Center2), c.Radius);
+                            break;
+                        }
                     case ShapeType.Hull:
-                    {
-                        B3Aabb local = shape.GetHullLocalBounds();
-                        float3 mid = (local.LowerBound + local.UpperBound) * 0.5f;
-                        col.Type = 2;
-                        col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, mid), 0f);
-                        col.Data = new float4((local.UpperBound - local.LowerBound) * 0.5f, 0f);
-                        break;
-                    }
+                        {
+                            B3Aabb local = shape.GetHullLocalBounds();
+                            float3 mid = (local.LowerBound + local.UpperBound) * 0.5f;
+                            col.Type = 2;
+                            col.Pos = new float4(tf.Position + math.rotate(tf.Rotation, mid), 0f);
+                            col.Data = new float4((local.UpperBound - local.LowerBound) * 0.5f, 0f);
+                            break;
+                        }
                     case ShapeType.HeightField:
-                    {
-                        // Terrain collides exactly: the component's sampled grid rides on the GPU
-                        // and is bilinearly sampled per particle. Fields with no live
-                        // Box3DTerrainShape (created straight through the API) have no grid to
-                        // sample and keep the bounding-box treatment below.
-                        if (!Box3DTerrainShape.TryGetLiveField(_overlap[i], out Box3DTerrainShape terrain)) goto default;
-                        float3 fieldScale = terrain.FieldScale;
-                        col.Type = 3;
-                        col.Rot = new float4(0f, 0f, 0f, 1f);
-                        col.Pos = new float4(terrain.FieldOrigin, 0f);
-                        col.Data = new float4(fieldScale, terrain.SampleCountZ);
-                        col.Aux0 = TerrainHeightsOffset(terrain);
-                        col.Aux1 = terrain.SampleCountX;
-                        break;
-                    }
+                        {
+                            // Terrain collides exactly: the component's sampled grid rides on the GPU
+                            // and is bilinearly sampled per particle. Fields with no live
+                            // Box3DTerrainShape (created straight through the API) have no grid to
+                            // sample and keep the bounding-box treatment below.
+                            if (!Box3DTerrainShape.TryGetLiveField(_overlap[i], out Box3DTerrainShape terrain)) goto default;
+                            float3 fieldScale = terrain.FieldScale;
+                            col.Type = 3;
+                            col.Rot = new float4(0f, 0f, 0f, 1f);
+                            col.Pos = new float4(terrain.FieldOrigin, 0f);
+                            col.Data = new float4(fieldScale, terrain.SampleCountZ);
+                            col.Aux0 = TerrainHeightsOffset(terrain);
+                            col.Aux1 = terrain.SampleCountX;
+                            break;
+                        }
                     default:
-                    {
-                        if (!ApproximateComplexShapes) continue;
-                        B3Aabb world = shape.GetAABB();
-                        col.Type = 2;
-                        col.Rot = new float4(0f, 0f, 0f, 1f);
-                        col.Pos = new float4((world.LowerBound + world.UpperBound) * 0.5f, 0f);
-                        // w = 1: a world-AABB approximation — only its top face acts on the
-                        // water (see the box branch in Box3DWaterSim.compute).
-                        col.Data = new float4((world.UpperBound - world.LowerBound) * 0.5f, 1f);
-                        break;
-                    }
+                        {
+                            if (!ApproximateComplexShapes) continue;
+                            B3Aabb bworld = shape.GetAABB();
+                            col.Type = 2;
+                            col.Rot = new float4(0f, 0f, 0f, 1f);
+                            col.Pos = new float4((bworld.LowerBound + bworld.UpperBound) * 0.5f, 0f);
+                            // w = 1: a world-AABB approximation — only its top face acts on the
+                            // water (see the box branch in Box3DWaterSim.compute).
+                            col.Data = new float4((bworld.UpperBound - bworld.LowerBound) * 0.5f, 1f);
+                            break;
+                        }
                 }
 
                 col.BodyIndex = -1;

--- a/Box3D.Hybrid/Water/Box3DWaterfall.cs
+++ b/Box3D.Hybrid/Water/Box3DWaterfall.cs
@@ -110,7 +110,7 @@ namespace Box3D.Hybrid
         // Cached scene search for the gravity preview: gizmos repaint continuously while
         // selected, and a full scene scan per repaint adds up. Re-searched at most twice a
         // second while no world exists.
-        private Box3DWorld _gizmoWorld;
+        private Vector3? _gizmoGravity = null;
         private float _nextGizmoSearch;
 
         private void OnDrawGizmosSelected()
@@ -122,12 +122,12 @@ namespace Box3D.Hybrid
             // Ballistic preview of where the stream goes: the lip center and both width edges,
             // integrated with the scene's gravity (the same curve the particles will fly).
             Gizmos.matrix = Matrix4x4.identity;
-            if (!_gizmoWorld && Time.realtimeSinceStartup >= _nextGizmoSearch)
+            if (_gizmoGravity == null && Time.realtimeSinceStartup >= _nextGizmoSearch)
             {
                 _nextGizmoSearch = Time.realtimeSinceStartup + 0.5f;
-                _gizmoWorld = FindAnyObjectByType<Box3DWorld>();
+                _gizmoGravity = IBox3DWorld.GetSceneGravityOrDefault(this, null);
             }
-            Vector3 gravity = _gizmoWorld ? _gizmoWorld.GravityVector : Physics.gravity;
+            Vector3 gravity = _gizmoGravity == null ? Physics.gravity : _gizmoGravity.Value;
 
             for (int edge = -1; edge <= 1; edge++)
             {


### PR DESCRIPTION
This PR is contains an API addition that allows users to optionally provide their own ``Box3DWorld`` implementation and instance. 
To do this, I've added two new constructs: the ``IBox3DWorld`` interface, and the ``WorldProvider`` delegate. API users are granted the freedom to implement their own ``IBox3DWorld`` while supplying an instance using ``WorldProvider``. All internal references to ``Box3DWorld.Instance`` have been replaced with ``IBox3DWorld.Get``, while ``Box3DWorld`` and ``Box3DEditorSimulation`` are now both implementing subclasses of ``IBox3DWorld``

This allows worlds to be context-dependent while still easily maintaining the one-world-per-scene rule enforced by the singleton, but API users now have the option to break this rule should they so choose.

For integration's sake, the default implementation of ``WorldProvider`` defers to ``Box3DWorld.Instance``, so this PR can act as a drop-in replacement with very few breaking changes to API users' code.

This change could cause some issues, since it allows API users the freedom to supply their own (potentially stale) worlds. To deal with problems caused by this, all implementing Box3D objects (primarily Box3DBody) no longer store a local reference to the Box3DWorld. They query for it using IBox3DWorld.Get() and immediately test for validity whenever the reference is needed. I think the flexibility of this system is worth the tiny bit of added overhead here, but I may have been a bit hasty with the implementation in some areas. 

Let me know if this could use some improving or tweaking to better fit the API style you're going for. This PR does not include changes to the Samples, so I'd need to address those.